### PR TITLE
Human detection chart with rtsp simulator

### DIFF
--- a/human-detection/Chart.yaml
+++ b/human-detection/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: human-detection
+description: A Helm chart to deploy components for sdp human detection demo
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/human-detection/README.md
+++ b/human-detection/README.md
@@ -1,1 +1,2 @@
-## human detection
+## Human Detection
+TODO doc

--- a/human-detection/templates/rtsp-simulator-deployment.yaml
+++ b/human-detection/templates/rtsp-simulator-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-rtsp-simulator
+  labels: 
+    release: {{ $.Release.Name }}-rtsp-simulator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      release: {{ $.Release.Name }}-rtsp-simulator
+  template:
+    metadata:
+      labels:
+        release: {{ $.Release.Name }}-rtsp-simulator
+    spec:
+      containers:
+      - name: rtsp-camera-simulator
+        image: {{ $.Values.images.rtspSimulator.repository | quote }}
+        imagePullPolicy: {{ $.Values.images.rtspSimulator.pullPolicy | quote }}
+        ports:
+        - name: rtsp
+          containerPort: {{ $.Values.global.camera.rtspPort }}
+          protocol: TCP
+        env:
+        - name: VIDEOS
+          value: {{ $.Values.global.camera.videos }}

--- a/human-detection/templates/rtsp-simulator-service.yaml
+++ b/human-detection/templates/rtsp-simulator-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-rtsp-simulator
+spec:
+  ports:
+  - name: rtsp
+    port: {{ $.Values.global.camera.rtspPort }}
+    targetPort: {{ $.Values.global.camera.rtspPort }}
+    protocol: TCP
+  selector:
+    release: {{ $.Release.Name }}-rtsp-simulator
+  type: ClusterIP

--- a/human-detection/values.yaml
+++ b/human-detection/values.yaml
@@ -1,0 +1,10 @@
+images:
+  rtspSimulator:
+    repository: "devops-repo.isus.emc.com:8116/nautilus/video-demos/rtsp-simulator:latest"
+    pullPolicy: "Always"
+
+global:
+  camera:
+    rtspPort: 8554
+    videos: "/opt/videos/3660928.mp4;30;cam1,/opt/videos/test4.mp4;24;cam2"
+    


### PR DESCRIPTION
Initial charts to deploy rtsp simulator for human detection demo.

**Test:**
Can deploy and play video from the simulator in camera recorder pipeline. Check full demo docs for more info.